### PR TITLE
fix: prevent binary files from being committed in PRs

### DIFF
--- a/.github/workflows/update-driver-toolkit.yml
+++ b/.github/workflows/update-driver-toolkit.yml
@@ -24,6 +24,8 @@ jobs:
         tar -xzf openshift-client-linux.tar.gz
         sudo mv oc /usr/local/bin/
         sudo chmod +x /usr/local/bin/oc
+        # Clean up installation files
+        rm -f openshift-client-linux.tar.gz kubectl oc
         
 
     - name: Generate driver toolkit JSON

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,17 @@
 kmod_images_ecr.csv
+
+# Binaries and installation files
+*.tar.gz
+oc
+kubectl
+openshift-client-*
+
+# Temporary files
+*.tmp
+*.temp
+.DS_Store
+
+# Secrets and auth files
+*.json.auth
+auth.json
+.config/containers/auth.json


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

- Add cleanup of OpenShift CLI installation files after use
- Enhance .gitignore to exclude binaries, temp files, and secrets
- Prevent GitHub's 100MB file size limit errors in PR creation
- Improve repository hygiene by excluding installation artifacts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
