### PR TITLE
feat: implement RPM-based Neuron driver source download

### DIFF
--- a/.github/workflows/build-kmod-kmm-images.yml
+++ b/.github/workflows/build-kmod-kmm-images.yml
@@ -32,10 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - name: Install container tools
+      - name: Install container tools and RPM utilities
         run: |
           sudo apt-get update
-          sudo apt-get install -y podman
+          sudo apt-get install -y podman rpm2cpio cpio
       
       - name: Build images for driver ${{ matrix.driver }}
         env:


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

- replace git clone with official AWS Neuron RPM package download
- add download_neuron_driver_source() function for RPM extraction
- use rpm2cpio and cpio for cross-platform RPM extraction
- add rpm2cpio and cpio to required tool checks for local/dev environments
- update GitHub Actions workflow to install RPM utilities
- download from https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-{version}.noarch.rpm
- extract to usr/src/aws-neuronx-{version}/ following RPM structure
- maintain same container build interface with updated source path
- improve reliability by using official AWS packages instead of third-party git repo


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
