### PR TITLE
fix: correct return code handling to prevent silent build failures

### DIFF
--- a/build-kmod-kmm.sh
+++ b/build-kmod-kmm.sh
@@ -414,11 +414,15 @@ while IFS= read -r entry; do
         dtk_image=$(echo "$entry" | jq -r '.dtk')
         
         # Build kernel module for this version
-        if ! build_kernel_module_for_version "$version" "$dtk_image"; then
-            if [ $? -eq 2 ]; then
-                echo "Build skipped for OCP version $version (image already exists), continuing with next version..."
-                continue
-            fi
+        build_kernel_module_for_version "$version" "$dtk_image"
+        build_result=$?
+        
+        if [ $build_result -eq 2 ]; then
+            echo "Build skipped for OCP version $version (image already exists), continuing with next version..."
+            continue
+        elif [ $build_result -ne 0 ]; then
+            echo "Build failed for OCP version $version, exiting..."
+            exit $build_result
         fi
         
         # Create GHCR tag with driver and kernel version
@@ -464,11 +468,15 @@ while IFS= read -r entry; do
         dtk_image="${ECR_REGISTRY}/${DTK_ECR_REPOSITORY_NAME}:${version}"
         
         # Build kernel module for this version
-        if ! build_kernel_module_for_version "$version" "$dtk_image"; then
-            if [ $? -eq 2 ]; then
-                echo "Build skipped for OCP version $version (image already exists), continuing with next version..."
-                continue
-            fi
+        build_kernel_module_for_version "$version" "$dtk_image"
+        build_result=$?
+        
+        if [ $build_result -eq 2 ]; then
+            echo "Build skipped for OCP version $version (image already exists), continuing with next version..."
+            continue
+        elif [ $build_result -ne 0 ]; then
+            echo "Build failed for OCP version $version, exiting..."
+            exit $build_result
         fi
         
         # Create full tag with kernel version information


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

- capture return code before if statement to avoid 0 being overwritten
- properly handle return code 2 (skipped) vs 1 (failed) vs 0 (success)
- fail entire workflow on build failures instead of silently continuing
- ensure maintainers see red workflows when builds actually fail
- fix issue where existing images were detected but container build still ran
- prevent 'no such file or directory' errors when neuron.ko is missing

Critical fix: builds were silently failing and continuing to container build step without the required neuron.ko file, causing confusing error messages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
