### PR TITLE
fix: handle set -e conflict with return code 2 (skipped builds)

### DIFF
--- a/build-kmod-kmm.sh
+++ b/build-kmod-kmm.sh
@@ -413,9 +413,11 @@ while IFS= read -r entry; do
         # Get DTK image from Quay.io (from JSON entry)
         dtk_image=$(echo "$entry" | jq -r '.dtk')
         
-        # Build kernel module for this version
+        # Build kernel module for this version (disable exit-on-error to capture return code)
+        set +e
         build_kernel_module_for_version "$version" "$dtk_image"
         build_result=$?
+        set -e
         
         if [ $build_result -eq 2 ]; then
             echo "Build skipped for OCP version $version (image already exists), continuing with next version..."
@@ -467,9 +469,11 @@ while IFS= read -r entry; do
         # Get DTK image from ECR
         dtk_image="${ECR_REGISTRY}/${DTK_ECR_REPOSITORY_NAME}:${version}"
         
-        # Build kernel module for this version
+        # Build kernel module for this version (disable exit-on-error to capture return code)
+        set +e
         build_kernel_module_for_version "$version" "$dtk_image"
         build_result=$?
+        set -e
         
         if [ $build_result -eq 2 ]; then
             echo "Build skipped for OCP version $version (image already exists), continuing with next version..."


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

- temporarily disable exit-on-error around build_kernel_module_for_version calls
- allows proper capture of return code 2 (skipped) without script exit
- re-enable exit-on-error immediately after capturing return code
- fixes issue where script was exiting with code 2 instead of continuing
- maintains strict error handling for actual failures (return code 1)

Root cause: set -euo pipefail was causing script to exit on return code 2 before we could handle it as a 'skip' condition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
