### PR TITLE
fix: simplify release notes to show all unique tags

### DIFF
--- a/build-kmod-kmm.sh
+++ b/build-kmod-kmm.sh
@@ -118,7 +118,9 @@ manage_github_release() {
 
     release_notes+="## Usage\n\n"
     release_notes+="These images are designed to be used with the Kernel Module Manager (KMM) operator on OpenShift.\n"
-    release_notes+="Select the image that matches your AWS Inferentia / Trainium worker nodes kernel version.\n"
+    release_notes+="Select the image that matches your worker nodes kernel version or your OpenShift version:\n"
+    release_notes+="- Use kernel-based tags (e.g., \`${driver_version}-5.14.0-...\`) to match specific kernel versions\n"
+    release_notes+="- Use OCP-based tags (e.g., \`${driver_version}-ocp4.18.0\`) to match your OpenShift version\n"
 
     release_notes+="## Available Images\n\n"
     


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

- Remove complex OCP-to-kernel mapping logic that was error-prone
- Show all unique tags (both kernel-based and OCP-based) in clean list
- Eliminate duplicates with sort -u
- Keep release notes simple and user-friendly
- Users can see all available image tags and choose what they need

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
