### PR TITLE
fix: add pagination support for GitHub API calls in release notes

### DIFF
--- a/build-kmod-kmm.sh
+++ b/build-kmod-kmm.sh
@@ -100,9 +100,9 @@ manage_github_release() {
     # Query GHCR for all images matching this driver version
     echo "Querying GHCR for images matching neuron-driver:${driver_version}-*"
     
-    # Get all unique tags and sort them
+    # Get all unique tags with pagination and sort them
     local all_tags
-    all_tags=$(gh api \
+    all_tags=$(gh api --paginate \
         "/orgs/awslabs/packages/container/kmod-with-kmm-for-ai-chips-on-aws%2Fneuron-driver/versions" \
         --jq ".[] | select(.metadata.container.tags[]? | startswith(\"${driver_version}-\")) | .metadata.container.tags[]" \
         2>/dev/null | sort -u || echo "")


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

- Add --paginate flag to gh api command to fetch all container image versions
- Fixes issue where only first 30 results were returned due to API pagination
- Ensures all ~55-60 images per driver version are included in release notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
