### PR TITLE
feat: update driver-toolkit.sh scan range to OCP 4.20-4.22

### DIFF
--- a/driver-toolkit/driver-toolkit.sh
+++ b/driver-toolkit/driver-toolkit.sh
@@ -41,7 +41,7 @@ echo "[" > "$temp_json"
 
 first_entry=true
 for major in {4..4}; do
-    for minor in {19..21}; do
+    for minor in {20..22}; do
         page=1
         while true; do
             response=$(curl -s "https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/?onlyActiveTags=true&filter_tag_name=like:${major}.${minor}.&page=$page&limit=100")


### PR DESCRIPTION
Update the minor version loop in `driver-toolkit.sh` from `{19..21}` to `{20..22}` to match the supported OCP versions in `build-matrix.json` (drop 4.19, add 4.22).