### PR TITLE
fix: disable custom get_unmapped_area fop on RHEL 9.6+ (neuron 2.28+)

### DIFF
--- a/container/build-module.sh
+++ b/container/build-module.sh
@@ -38,18 +38,34 @@ if ! version_lt "${DRIVER_VERSION}" "2.22.2.0"; then
     sed -i 's/RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5)/RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4)/g' neuron_cdev.c
 fi
 
-# Patch for RHEL 9.6+ (kernel 5.14.0-570+)
-# Issue: neuron_mmap.h selects mm_get_unmapped_area() for RHEL >= 9.5, but on RHEL 9.6+
-#        that function does not exist (verified via /proc/kallsyms on 5.14.0-570.el9_6:
-#        no mm_get_unmapped_area symbol). The pre-9.5 fallback (mm->get_unmapped_area)
-#        also fails because the get_unmapped_area field was removed from mm_struct.
-# Fix: For RHEL 9.6+, call the global get_unmapped_area() instead. It exists, is
-#      EXPORT_SYMBOL'd (verified: __ksymtab_get_unmapped_area present), is declared in
-#      linux/mm.h, and its signature (file, addr, len, pgoff, flags) matches the macro args.
+# Patch for RHEL 9.6+ (kernel 5.14.0-570+) -- neuron 2.28+ only
+# Issue: 2.28.0.0 added a custom .get_unmapped_area fop (ncdev_get_unmapped_area ->
+#        nmmap_get_unmapped_area) for an EFA P2P 2MB-page optimization. Its helper macro
+#        resolves to a *get_unmapped_area kernel routine that is NOT module-linkable on
+#        RHEL 9.6+:
+#          - mm_get_unmapped_area() does not exist (verified via /proc/kallsyms on el9_6).
+#          - get_unmapped_area() is an inline calling the un-exported __get_unmapped_area()
+#            (verified: modpost "undefined!" on el9_8 / 5.14.0-687).
+#          - the pre-9.5 fallback mm->get_unmapped_area was removed from mm_struct.
+# Fix: Disable the custom fop on RHEL 9.6+ so the kernel uses its own internal VA
+#      placement (identical to pre-2.28 behavior); mmap still works. The EFA 2MB
+#      optimization is sacrificed, which is moot since EFA P2P is not available on RHEL.
+#        1) neutralize the helper macro so the now-unused nmmap_get_unmapped_area no longer
+#           references any un-exported symbol (fixes modpost link error);
+#        2) set the fop to NULL so kernel default placement is used (correctness);
+#        3) mark the now-unused static fop function __maybe_unused (avoids -Werror).
+# Safe for older drivers (2.26.5.0, 2.27.4.0): they contain none of these lines, so every
+# sed below is a guaranteed no-op.
 RHEL_MINOR=$(echo "${KERNEL_VERSION}" | sed -n 's/.*el[0-9][_\.]\([0-9]*\).*/\1/p')
 if [ "${RHEL_MINOR:-0}" -ge 6 ] 2>/dev/null; then
-    echo "RHEL 9.${RHEL_MINOR} detected, patching neuron_mmap.h to use global get_unmapped_area()..."
-    sed -i 's/mm_get_unmapped_area(current->mm, filep, addr, len, pgoff, flags)/get_unmapped_area(filep, addr, len, pgoff, flags)/g' neuron_mmap.h
+    echo "RHEL 9.${RHEL_MINOR} detected, disabling custom .get_unmapped_area fop (neuron 2.28+)..."
+    # 1) neutralize helper macro (both RHEL >=9.5 and pre-9.5 branches) -> no kernel symbol ref
+    sed -i 's/mm_get_unmapped_area(current->mm, filep, addr, len, pgoff, flags)/(addr)/g' neuron_mmap.h
+    sed -i 's/current->mm->get_unmapped_area(filep, addr, len, pgoff, flags)/(addr)/g' neuron_mmap.h
+    # 2) do not register the custom fop -> kernel uses default VA placement
+    sed -i 's/\.get_unmapped_area = ncdev_get_unmapped_area,/.get_unmapped_area = NULL,/' neuron_cdev.c
+    # 3) the fop function is now unused; prevent -Werror=unused-function
+    sed -i 's/static unsigned long ncdev_get_unmapped_area(/static unsigned long __maybe_unused ncdev_get_unmapped_area(/' neuron_cdev.c
 fi
 
 # Build the module


### PR DESCRIPTION
Supersedes the el9_6-only get_unmapped_area substitution, which fixed compilation on el9_6 but failed at modpost on el9_8 (5.14.0-687):
  ERROR: modpost: "__get_unmapped_area" undefined!

Root cause: the 2.28.0.0 EFA P2P optimization's .get_unmapped_area fop chain ends in a *get_unmapped_area routine that is not module-linkable on RHEL 9.6+:
  - mm_get_unmapped_area() does not exist (verified on el9_6 kallsyms);
  - get_unmapped_area() is an inline -> un-exported __get_unmapped_area (verified: modpost undefined on el9_8);
  - mm->get_unmapped_area field was removed from mm_struct.

Fix (uniform for all RHEL 9.6+): disable the custom fop so the kernel performs VA placement internally (pre-2.28 behavior; mmap still works). The EFA 2MB-page optimization is sacrificed, which is moot as EFA P2P is not available on RHEL.
  1) neutralize the helper macro -> nmmap_get_unmapped_area no longer
     references any un-exported symbol (fixes modpost);
  2) set .get_unmapped_area = NULL -> kernel default placement;
  3) mark the now-unused static fop fn __maybe_unused (avoids -Werror).

Validated: sed patterns match real 2.28.0.0 source and produce valid C with zero references to the removed/unexported symbols. No-op for older drivers (2.26.5.0, 2.27.4.0), which lack this code entirely.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
